### PR TITLE
Fix size of volume serial number, so file ID shows properly.

### DIFF
--- a/Page06NtFileInfo.cpp
+++ b/Page06NtFileInfo.cpp
@@ -618,7 +618,7 @@ TStructMember FileVolumeNameInformationMembers[] =
 
 TStructMember FileIdInformationMembers[] =
 {
-    {_T("VolumeSerialNumber"), TYPE_UINT64,     sizeof(ULONG)},
+    {_T("VolumeSerialNumber"), TYPE_UINT64,     sizeof(LARGE_INTEGER)},
     {_T("FileId"),             TYPE_FILEID128,  sizeof(FILE_ID_128)},
     {NULL, TYPE_NONE, 0}
 };


### PR DESCRIPTION
FileId was showing half of the volume serial number and half of the file ID.
I compared with fsutil file queryfileid and it's consistent now.